### PR TITLE
Parse dhcp-subnet without ttl option

### DIFF
--- a/lib/smart_proxy_dhcp_dnsmasq/dhcp_dnsmasq_subnet_service.rb
+++ b/lib/smart_proxy_dhcp_dnsmasq/dhcp_dnsmasq_subnet_service.rb
@@ -103,12 +103,12 @@ module Proxy::DHCP::Dnsmasq
 
             @lease_file = value
           when 'dhcp-range'
-            data = value.split(',')
+            data = value.split(',').pop(4)
 
-            ttl = data.pop
-            mask = data.pop
-            range_to = data.pop
-            range_from = data.pop
+            range_from = data[0]
+            range_to = data[1]
+            mask = data[2]
+            ttl = data[3] || '1h' # the default from the man page
 
             ttl = case ttl[-1]
                   when 'h'


### PR DESCRIPTION
Hello! Finally I am getting to test your plugin, works nicely. I am integrating it with libvirt/dnsmasq and it looks like libvirt creates the following configuration:

```
strict-order
pid-file=/run/libvirt/network/default.pid
except-interface=lo
bind-dynamic
interface=virbr0
dhcp-range=192.168.122.2,192.168.122.254,255.255.255.0
dhcp-no-override
dhcp-authoritative
enable-tftp
tftp-root=/var/lib/dnsmasq/tftp
dhcp-boot=pxelinux.0
dhcp-lease-max=253
dhcp-hostsfile=/var/lib/libvirt/dnsmasq/default.hostsfile
addn-hosts=/var/lib/libvirt/dnsmasq/default.addnhosts
dhcp-optsfile=/var/lib/libvirt/dnsmasq/foreman-default/dhcpopts.conf
dhcp-hostsfile=/var/lib/libvirt/dnsmasq/foreman-default/dhcphosts
dhcp-leasefile=/var/lib/dnsmasq/foreman-default.leases
```

The parser errors out because `dhcp-range` does not have the TTL (last element). By default it is one hour, so I fixed it.