### PR TITLE
Unused_ip fix

### DIFF
--- a/lib/smart_proxy_dhcp_dnsmasq/dhcp_dnsmasq_plugin.rb
+++ b/lib/smart_proxy_dhcp_dnsmasq/dhcp_dnsmasq_plugin.rb
@@ -11,7 +11,8 @@ module Proxy::DHCP::Dnsmasq
     default_settings config: '/etc/dnsmasq.conf',
                      target_dir: '/var/lib/foreman-proxy/dhcp/',
                      lease_file: '/var/lib/dnsmasq/dhcp.leases',
-                     reload_cmd: 'systemctl reload dnsmasq'
+                     reload_cmd: 'systemctl reload dnsmasq',
+                     blacklist_duration_minutes: 30
 
     validate_readable :lease_file
 

--- a/lib/smart_proxy_dhcp_dnsmasq/dhcp_dnsmasq_version.rb
+++ b/lib/smart_proxy_dhcp_dnsmasq/dhcp_dnsmasq_version.rb
@@ -3,7 +3,7 @@
 module Proxy
   module DHCP
     module Dnsmasq
-      VERSION = '1.0'
+      VERSION = '1.1'
     end
   end
 end


### PR DESCRIPTION
Trivial changes to make the unused_ip API/"Suggest new" functionality work when using dnsmasq as a DHCP provider.

I couldn't find the actual pull request template (the link from the docs 404's), I'd be happy to fill it out if needs be (and if somebody can direct me to it...)

Literally just added a default setting value for "blacklist_duration_minutes" in dhcp_dnsmasq_plugin.rb and bumped the version number.

settings was passing nil where the "blacklist_duration_minutes" value wasn't in config which was clobbering the default argument for initialize for Proxy::DHCP::FreeIps which was causing FreeIps.mark_ip_as_allocated to barf breaking the unused_ip API.