### PR TITLE
Add blacklist duration setting to dnsmasq plugin

### DIFF
--- a/lib/smart_proxy_dhcp_dnsmasq/dhcp_dnsmasq_plugin.rb
+++ b/lib/smart_proxy_dhcp_dnsmasq/dhcp_dnsmasq_plugin.rb
@@ -11,7 +11,8 @@ module Proxy::DHCP::Dnsmasq
     default_settings config: '/etc/dnsmasq.conf',
                      target_dir: '/var/lib/foreman-proxy/dhcp/',
                      lease_file: '/var/lib/dnsmasq/dhcp.leases',
-                     reload_cmd: 'systemctl reload dnsmasq'
+                     reload_cmd: 'systemctl reload dnsmasq',
+                     blacklist_duration_minutes: 30 * 60
 
     validate_readable :lease_file
 


### PR DESCRIPTION
Set default value for `blacklist_duration_minutes` in DHCP dnsmasq provider
This aligns dnsmasq with other DHCP providers (e.g. ISC, Infoblox), which already define a default.  

Redmine issue: https://projects.theforeman.org/issues/38729
